### PR TITLE
Fix #167

### DIFF
--- a/src/rc.c
+++ b/src/rc.c
@@ -168,11 +168,11 @@ bool receive_rc()
       //switch is on/off dependent on its default direction as set in the params/init_switches
       if (switches[channel].direction <  0)
       {
-        switch_values[channel] = pwm_read(switches[channel].channel) < 1500;
+        switch_values[channel] = pwm_read(switches[channel].channel) < 1150;
       }
       else
       {
-        switch_values[channel] = pwm_read(switches[channel].channel) >= 1500;
+        switch_values[channel] = pwm_read(switches[channel].channel) >= 1850;
       }
     }
     else


### PR DESCRIPTION
It turns out, that a lot of RC receivers have the default behavior to send 1500's across the board when there is no RC transmitter connected.  There is a bit of noise on these signals, so depending on the receiver, if you are using an arming channel, it can be read as active if it receives something like a 1506.

This fixes that.