### PR TITLE
Cleaned up turbotrig includes

### DIFF
--- a/boards/naze/Makefile
+++ b/boards/naze/Makefile
@@ -133,7 +133,6 @@ CXXSOURCES =    $(addprefix $(ROSFLIGHT_DIR)/src/, $(ROSFLIGHT_SRC)) \
 
 # Set up Include Directoreis
 INCLUDE_DIRS =	$(BREEZY_DIR) \
-                $(TURBOTRIG_DIR) \
                 $(ROSFLIGHT_DIR)/include \
                 $(ROSFLIGHT_DIR)/lib \
                 $(STDPERIPH_DIR)/inc \

--- a/include/controller.h
+++ b/include/controller.h
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <turbovec.h>
+#include <turbotrig/turbovec.h>
 
 #include "command_manager.h"
 #include "estimator.h"

--- a/include/estimator.h
+++ b/include/estimator.h
@@ -36,8 +36,8 @@
 #include <stdbool.h>
 #include <math.h>
 
-#include <turbovec.h>
-#include <turbotrig.h>
+#include <turbotrig/turbovec.h>
+#include <turbotrig/turbotrig.h>
 
 namespace rosflight_firmware
 {

--- a/include/sensors.h
+++ b/include/sensors.h
@@ -34,7 +34,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <turbovec.h>
+#include <turbotrig/turbovec.h>
 
 namespace rosflight_firmware
 {

--- a/lib/turbotrig/turbovec.cpp
+++ b/lib/turbotrig/turbovec.cpp
@@ -34,8 +34,8 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 
 
-#include "turbovec.h"
-#include "turbotrig.h"
+#include <turbotrig/turbovec.h>
+#include <turbotrig/turbotrig.h>
 
 
 void pfquat() __attribute__((unused));

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -35,7 +35,7 @@
 #include "sensors.h"
 #include "rosflight.h"
 
-#include <turbovec.h>
+#include <turbotrig/turbovec.h>
 
 namespace rosflight_firmware
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,30 +1,28 @@
 cmake_minimum_required(VERSION 2.6)
 
 add_definitions(-std=c++11)
-add_definitions(-DUSING_STDLIB_PRINTF)
- 
+
 # Locate GTest
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
- 
-include_directories(../lib)
-include_directories(../lib/turbotrig)
+
 include_directories(../include)
+include_directories(../lib)
 include_directories(${EIGEN3_INCLUDE_DIRS})
 include_directories(/usr/include/eigen3)
 
 
 set(ROSFLIGHT_SRC
     ../src/rosflight.cpp
-    ../src/param.cpp 
-    ../src/sensors.cpp 
-    ../src/state_manager.cpp 
-    ../src/estimator.cpp 
-    ../src/mavlink.cpp 
+    ../src/param.cpp
+    ../src/sensors.cpp
+    ../src/state_manager.cpp
+    ../src/estimator.cpp
+    ../src/mavlink.cpp
     ../src/nanoprintf.cpp
-    ../src/controller.cpp 
-    ../src/command_manager.cpp 
-    ../src/rc.cpp 
+    ../src/controller.cpp
+    ../src/command_manager.cpp
+    ../src/rc.cpp
     ../src/mixer.cpp
     ../lib/turbotrig/turbotrig.cpp
     ../lib/turbotrig/turbovec.cpp

--- a/test/estimator_test.cpp
+++ b/test/estimator_test.cpp
@@ -2,7 +2,7 @@
 #include "math.h"
 #include "rosflight.h"
 #include "test_board.h"
-#include "turbotrig.h"
+#include <turbotrig/turbotrig.h>
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
 #include "eigen3/unsupported/Eigen/MatrixFunctions"

--- a/test/turbotrig_test.cpp
+++ b/test/turbotrig_test.cpp
@@ -32,8 +32,8 @@
  */
 
 #include "math.h"
-#include "turbotrig.h"
-#include "turbovec.h"
+#include <turbotrig/turbotrig.h>
+#include <turbotrig/turbovec.h>
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Dense"
 #include "eigen3/Eigen/Geometry"


### PR DESCRIPTION
This helps clean up the number of include directories we have to specify in our make/cmake files