### PR TITLE
Fixed extraneous parenthesis in custom udev rule

### DIFF
--- a/docs/user-guide/autopilot-setup.md
+++ b/docs/user-guide/autopilot-setup.md
@@ -19,7 +19,7 @@ sudo systemctl stop ModemManager.service
 ```
 * Add the custom udev rule so linux handles the flight controller properly
 ``` bash
-echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"') | sudo tee /etc/udev/rules.d/45-stdfu-permissions.rules > /dev/null
+echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/45-stdfu-permissions.rules > /dev/null
 ```
 * Load the firmware and flash using cleanflight configurator
     * Open the configurator, open firmware flasher.  Connect your flight controller, and make sure that you have selected the right port (or DFU in the case of F4-based boards).  Then select "Load Firmware (Local)" and  select your .hex file you downloaded earlier.


### PR DESCRIPTION
bash/zsh runs into a parsing error on the command copied directly from the docs, I fixed the command.

Pull Request Guidelines

all pull requests should adhere to the [style guide](http://docs.rosflight.org/en/developer_docs/developer-guide/style_guide/)

and should pass the unit tests

``` bash
./run_tests.sh
```
Any pull request not adhering to these guidelines will be rejected.
