### PR TITLE
Fix 305

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: "trusty"
+dist: "xenial"
 language: cpp
 
 addons:
@@ -6,9 +6,9 @@ addons:
     packages:
       - build-essential
       - libc6-i386
-      - lib32bz2-1.0
-      - lib32ncurses5
-      - lib32z1
+      - libbz2-1.0:i386
+      - libncurses5:i386
+      - libz1:i386
       - cmake
       - libgtest-dev
       - libeigen3-dev

--- a/include/sensors.h
+++ b/include/sensors.h
@@ -145,7 +145,6 @@ private:
   bool calibrating_acc_flag_ = false;
   bool calibrating_gyro_flag_ = false;
   uint8_t next_sensor_to_update_ = BAROMETER;
-  uint8_t next_sensor_to_look_for_ = BAROMETER;
   void init_imu();
   void calibrate_accel(void);
   void calibrate_gyro(void);

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -207,24 +207,10 @@ void Sensors::look_for_disabled_sensors()
   if (rf_.board_.clock_millis() > last_time_look_for_disarmed_sensors_ + 1000)
   {
     last_time_look_for_disarmed_sensors_ = rf_.board_.clock_millis();
-    switch (next_sensor_to_look_for_)
-    {
-    case BAROMETER:
-      rf_.board_.baro_update();
-      break;
-    case MAGNETOMETER:
-      rf_.board_.mag_update();
-      break;
-    case DIFF_PRESSURE:
-      rf_.board_.diff_pressure_update();
-      break;
-    case SONAR:
-      rf_.board_.sonar_update();
-      break;
-    default:
-      break;
-    }
-    next_sensor_to_look_for_ = (next_sensor_to_look_for_ + 1) % NUM_LOW_PRIORITY_SENSORS;
+    rf_.board_.baro_update();
+    rf_.board_.mag_update();
+    rf_.board_.diff_pressure_update();
+    rf_.board_.sonar_update();
   }
 }
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -159,7 +159,8 @@ void Sensors::update_other_sensors()
     break;
 
   case DIFF_PRESSURE:
-    if (rf_.board_.diff_pressure_present() || data_.diff_pressure_present) {
+    if (rf_.board_.diff_pressure_present() || data_.diff_pressure_present)
+    {
       // if diff_pressure is currently present OR if it has historically been
       //   present (diff_pressure_present default is false)
       rf_.board_.diff_pressure_update(); //update assists in recovering sensor if it temporarily disappears

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -159,18 +159,23 @@ void Sensors::update_other_sensors()
     break;
 
   case DIFF_PRESSURE:
-    if (rf_.board_.diff_pressure_present())
-    {
-      data_.diff_pressure_present = true;
-      float raw_pressure;
-      float raw_temp;
-      rf_.board_.diff_pressure_update();
-      rf_.board_.diff_pressure_read(&raw_pressure, &raw_temp);
-      data_.diff_pressure_valid = diff_outlier_filt_.update(raw_pressure, &data_.diff_pressure);
-      if (data_.diff_pressure_valid)
+    if (rf_.board_.diff_pressure_present() || data_.diff_pressure_present) {
+      // if diff_pressure is currently present OR if it has historically been
+      //   present (diff_pressure_present default is false)
+      rf_.board_.diff_pressure_update(); //update assists in recovering sensor if it temporarily disappears
+
+      if (rf_.board_.diff_pressure_present())
       {
-        data_.diff_pressure_temp = raw_temp;
-        correct_diff_pressure();
+        data_.diff_pressure_present = true;
+        float raw_pressure;
+        float raw_temp;
+        rf_.board_.diff_pressure_read(&raw_pressure, &raw_temp);
+        data_.diff_pressure_valid = diff_outlier_filt_.update(raw_pressure, &data_.diff_pressure);
+        if (data_.diff_pressure_valid)
+        {
+          data_.diff_pressure_temp = raw_temp;
+          correct_diff_pressure();
+        }
       }
     }
     break;


### PR DESCRIPTION
Fixes for #305

1. Airspeed sensor is now recovered if there's intermittent external 5v power loss mid-flight (in this case the sensor must have been recognized before arming)
2. Airspeed sensor is now recognized when disarmed and if external 5v power is provided after boot up

For 2 above, I had to remove the [switch statement](https://github.com/rosflight/firmware/commit/eb269656205e2569a4330dc5c5fec8bd3333a88f#diff-d66352a6caa2830e83e1fd01f7619919L210) from sensors.look_for_disabled_sensors(). Functionally this means airspeed (and all other sensors) are checked once every second instead of once every 4 seconds. For whatever reason I could not get airspeed to pickup with the switch statement in place, even with increased check frequency (every 200ms instead of 1s). It was getting called in the switch. I'm willing to dig into this more if you feel this is an unsuitable fix.

How I reproduce the problem:
1. Plug in board via USB (no external power yet)
2. Start rosflight_io and verify there is no airspeed topic with `rostopic list`
3. Plug in external power. On current master, `rostopic list` will _not_ show /airspeed, this branch will


The CI build was also broken, so I updated the travis script to use xenial, and adjusted the packages accordingly. Builds now pass. Hope this is okay