### PR TITLE
don't write beyond the end of esc_out_

### DIFF
--- a/boards/airbourne/airbourne_board.cpp
+++ b/boards/airbourne/airbourne_board.cpp
@@ -371,7 +371,10 @@ void AirbourneBoard::pwm_disable()
 
 void AirbourneBoard::pwm_write(uint8_t channel, float value)
 {
-  esc_out_[channel].write(value);
+  if (channel < PWM_NUM_OUTPUTS)
+  {
+    esc_out_[channel].write(value);
+  }
 }
 
 bool AirbourneBoard::rc_lost()


### PR DESCRIPTION
I know this isn't into master - but gps is effectively operating as master right now.

This fixes the hardfault I was getting with the aux_command. Since `PWM_NUM_OUTPUTS` is the number of outputs the board supports, and the length of `esc_out_`, I think this is a reasonable way to fix this. Another option would be to reduce the size of the `aux_command` message to send only 11 values, but that would be more work. Happy to do it if you'd prefer that approach.