### PR TITLE
fixed init_param bug to include null (strlen+1)

### DIFF
--- a/src/param.cpp
+++ b/src/param.cpp
@@ -54,7 +54,8 @@ Params::Params(ROSflight& _rf) :
 // local function definitions
 void Params::init_param_int(uint16_t id, const char name[PARAMS_NAME_LENGTH], int32_t value)
 {
-  const uint8_t len = (strlen(name)>PARAMS_NAME_LENGTH) ? PARAMS_NAME_LENGTH : strlen(name);
+  // copy cstr including '\0' or until maxlen
+  const uint8_t len = (strlen(name)>=PARAMS_NAME_LENGTH) ? PARAMS_NAME_LENGTH : strlen(name)+1;
   memcpy(params.names[id], name, len);
   params.values[id].ivalue = value;
   params.types[id] = PARAM_TYPE_INT32;
@@ -62,7 +63,8 @@ void Params::init_param_int(uint16_t id, const char name[PARAMS_NAME_LENGTH], in
 
 void Params::init_param_float(uint16_t id, const char name[PARAMS_NAME_LENGTH], float value)
 {
-  const uint8_t len = (strlen(name)>PARAMS_NAME_LENGTH) ? PARAMS_NAME_LENGTH : strlen(name);
+  // copy cstr including '\0' or until maxlen
+  const uint8_t len = (strlen(name)>=PARAMS_NAME_LENGTH) ? PARAMS_NAME_LENGTH : strlen(name)+1;
   memcpy(params.names[id], name, len);
   params.values[id].fvalue = value;
   params.types[id] = PARAM_TYPE_FLOAT;


### PR DESCRIPTION
sometimes i hate cstrings

`strlen` does not count `\0`, so when `strlen()<PARAMS_NAME_LENGTH` the `+1` is needed so that `lookup_param_id` knows to stop.