### PR TITLE
Small Cleanup to Firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ scripts/parameter-descriptions.md
 *.synctex.gz
 *.bbl
 *.blg
+*.cflags
+*.cxxflags

--- a/include/estimator.h
+++ b/include/estimator.h
@@ -61,6 +61,21 @@ public:
 
   inline const State &state() const { return state_; }
 
+  inline const turbomath::Vector& bias()
+  {
+      return bias_;
+  }
+
+  inline const turbomath::Vector& accLPF()
+  {
+      return accel_LPF_;
+  }
+
+  inline const turbomath::Vector& gyroLPF()
+  {
+      return gyro_LPF_;
+  }
+
   void init();
   void run();
   void reset_state();

--- a/include/param.h
+++ b/include/param.h
@@ -35,15 +35,6 @@
 #include <cstdint>
 #include <functional>
 
-#ifndef GIT_VERSION_HASH
-#define GIT_VERSION_HASH 0x00
-#pragma message "GIT_VERSION_HASH Undefined, setting to 0x00!"
-#endif
-
-#ifndef GIT_VERSION_STRING
-#define GIT_VERSION_STRING "empty"
-#endif
-
 namespace rosflight_firmware
 {
 

--- a/src/param.cpp
+++ b/src/param.cpp
@@ -29,8 +29,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-
 #include <cstdint>
 #include <cstring>
 
@@ -40,6 +38,21 @@
 #include "param.h"
 
 #include "rosflight.h"
+
+#ifndef GIT_VERSION_HASH
+#define GIT_VERSION_HASH 0x00
+#pragma message "GIT_VERSION_HASH Undefined, setting to 0x00!"
+#endif
+#ifndef GIT_VERSION_STRING
+#define GIT_VERSION_STRING "empty"
+#pragma message "GIT_VERSION_STRING Undefined, setting to \"empty\"!"
+#endif
+
+// Uncomment to view contents of GIT_VERSION_HASH and GIT_VERSION STRING
+//#define STRINGIFY(s) XSTRINGIFY(s)
+//#define XSTRINGIFY(s) #s
+//#pragma message( "GIT_VERSION_HASH: " STRINGIFY(GIT_VERSION_HASH))
+//#pragma message( "GIT_VERSION_STRING: " GIT_VERSION_STRING)
 
 namespace rosflight_firmware
 {
@@ -367,6 +380,8 @@ bool Params::set_param_by_name_int(const char name[PARAMS_NAME_LENGTH], int32_t 
 
 bool Params::set_param_by_name_float(const char name[PARAMS_NAME_LENGTH], float value)
 {
-  return set_param_by_name_int(name, reinterpret_cast<int32_t &>(value));
+  param_value_t tmp;
+  tmp.fvalue = value;
+  return set_param_by_name_int(name, tmp.ivalue);
 }
 }


### PR DESCRIPTION
A few clean-up Things.

1 - Expose Bias and LPF values of estimator as const refs.  (For post-process inspection)
2 - Move `GIT_VERSION_HASH` checks to `param.cpp` so they aren't triggered by includes in other projects
3 - Use the `union` to deal with type aliasing, to avoid triggering `strict-aliasing` error.