### PR TITLE
Add MkDocs strict build to test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_script:
 
 script:
   - ./scripts/run_tests.sh
-  - mkdocs build
 
 deploy:
   provider: pages

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -43,6 +43,11 @@ echo_blue "Test 4: Run test suite"
 ./unit_tests
 print_result $?
 
+echo_blue "Test 5: Build MkDocs documentation"
+cd ../..
+mkdocs build -s
+print_result $?
+
 
 if [ $EXIT_CODE -eq 0 ]; then
   echo_green "All tests passed!"


### PR DESCRIPTION
I've been setting up the webhook to host the documentation on our own server rather than GitHub pages, and thought I'd take the opportunity to improve the test script to ensure the documentation always builds. This PR changes two things:

  - Adds the mkdocs build to the test script (instead of just `.travis.yml` so the user gets feedback before pushing if there's an issue)
  - Runs the mkdocs build command in strict mode, so that it fails if there's a warning instead of ignoring things like missing images, bad links, etc.