### PR TITLE
Remove mkdocs github pages deploy from travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,3 @@ before_script:
 
 script:
   - ./scripts/run_tests.sh
-
-deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  local_dir: site
-  repo: rosflight/rosflight.github.io
-  target_branch: master
-  fqdn: docs.rosflight.org
-  on:
-    branch: master


### PR DESCRIPTION
This pull request removes the GitHub pages deploy step in our Travis configuration. Since I've moved documentation hosting to our own server to avoid the certificate issues we're having, that step is no longer needed.

Along with previous changes, this closes #362 