### PR TITLE
Verbose RC Override

### DIFF
--- a/comms/mavlink/mavlink.cpp
+++ b/comms/mavlink/mavlink.cpp
@@ -316,7 +316,7 @@ void Mavlink::send_sonar(uint8_t system_id, /* TODO enum type*/uint8_t type, flo
 void Mavlink::send_status(uint8_t system_id,
                           bool armed,
                           bool failsafe,
-                          bool rc_override,
+                          uint16_t rc_override,
                           bool offboard,
                           uint8_t error_code,
                           uint8_t control_mode,

--- a/comms/mavlink/mavlink.h
+++ b/comms/mavlink/mavlink.h
@@ -87,7 +87,7 @@ public:
   void send_status(uint8_t system_id,
                    bool armed,
                    bool failsafe,
-                   bool rc_override,
+                   uint16_t rc_override,
                    bool offboard,
                    uint8_t error_code,
                    uint8_t control_mode,

--- a/include/command_manager.h
+++ b/include/command_manager.h
@@ -192,7 +192,7 @@ private:
   /**
    * @brief Checks which channels are overridden
    * @details There are many reasons that a channel could be overriden. These reasons include:
-   * 	- A stick is deviated
+   * 	- A stick is deflected
    * 	-	The commanded throttle is less than the RC throttle, and the MIN_THROTTLE parameter is set
    * 	-	The attitude or throttle override switch is flipped
    * 	-	The onboard computer has not sent any commands recently
@@ -212,6 +212,18 @@ public:
   CommandManager(ROSflight &_rf);
   void init();
   bool run();
+   /**
+   * @brief Checks which channels are overridden, and why
+   * @details There are many reasons that a channel could be overriden. These reasons include:
+   * 	- A stick is deflected
+   * 	-	The commanded throttle is less than the RC throttle, and the MIN_THROTTLE parameter is set
+   * 	-	The attitude or throttle override switch is flipped
+   * 	-	The onboard computer has not sent any commands recently
+   * The returned bitfield indicates which reasons have caused an override.
+   * Because c++ can use integers as booleans, this function can be treated as providing a boolean
+   * This value is updated when run is called if a new RC command is available
+   * @return A bitfield, with overriden reasons indicated
+   */
   uint16_t get_rc_override();
   bool offboard_control_active();
   void set_new_offboard_command(control_t new_offboard_command);

--- a/include/command_manager.h
+++ b/include/command_manager.h
@@ -212,7 +212,7 @@ public:
   CommandManager(ROSflight &_rf);
   void init();
   bool run();
-  bool rc_override_active();
+  uint16_t get_rc_override();
   bool offboard_control_active();
   void set_new_offboard_command(control_t new_offboard_command);
   void set_new_rc_command(control_t new_rc_command);

--- a/include/interface/comm_link.h
+++ b/include/interface/comm_link.h
@@ -163,7 +163,7 @@ public:
     virtual void send_status(uint8_t system_id,
                              bool armed,
                              bool failsafe,
-                             bool rc_override,
+                             uint16_t rc_override,
                              bool offboard,
                              uint8_t error_code,
                              uint8_t control_mode,

--- a/src/comm_manager.cpp
+++ b/src/comm_manager.cpp
@@ -449,7 +449,7 @@ void CommManager::send_status(void)
   comm_link_.send_status(sysid_,
                          RF_.state_manager_.state().armed,
                          RF_.state_manager_.state().failsafe,
-                         RF_.command_manager_.rc_override_active(),
+                         RF_.command_manager_.get_rc_override(),
                          RF_.command_manager_.offboard_control_active(),
                          RF_.state_manager_.state().error_codes,
                          control_mode,

--- a/src/command_manager.cpp
+++ b/src/command_manager.cpp
@@ -187,14 +187,11 @@ uint16_t CommandManager::determine_override_status()
     if(!(muxes[channel].onboard->active))
       rc_override |= channel_override_[channel].offboard_inactive_override_reason;
   }
-  if(muxes[MUX_F].onboard->active) // The throttle has unique override behavior
-  {
-    if(RF_.params_.get_param_int(PARAM_RC_OVERRIDE_TAKE_MIN_THROTTLE))
-      if(muxes[MUX_F].rc->value < muxes[MUX_F].onboard->value)
-        rc_override |= OVERRIDE_T;
-  }
-  else
+  if(!(muxes[MUX_F].onboard->active)) // The throttle has unique override behavior
     rc_override |= OVERRIDE_OFFBOARD_T_INACTIVE;
+  if(RF_.params_.get_param_int(PARAM_RC_OVERRIDE_TAKE_MIN_THROTTLE))
+    if(muxes[MUX_F].rc->value < muxes[MUX_F].onboard->value)
+      rc_override |= OVERRIDE_T;
   return rc_override;
 }
 

--- a/src/command_manager.cpp
+++ b/src/command_manager.cpp
@@ -158,78 +158,56 @@ bool CommandManager::stick_deviated(MuxChannel channel)
   uint32_t now = RF_.board_.clock_millis();
 
   // if we are still in the lag time, return true
-  if (now  < rc_stick_override_[channel].last_override_time + RF_.params_.get_param_int(PARAM_OVERRIDE_LAG_TIME))
+  if (now  < channel_override_[channel].last_override_time + RF_.params_.get_param_int(PARAM_OVERRIDE_LAG_TIME))
   {
     return true;
   }
   else
   {
-    if (fabsf(RF_.rc_.stick(rc_stick_override_[channel].rc_channel))
+    if (fabsf(RF_.rc_.stick(channel_override_[channel].rc_channel))
         > RF_.params_.get_param_float(PARAM_RC_OVERRIDE_DEVIATION))
     {
-      rc_stick_override_[channel].last_override_time = now;
+      channel_override_[channel].last_override_time = now;
       return true;
     }
     return false;
   }
 }
-
-bool CommandManager::do_roll_pitch_yaw_muxing(MuxChannel channel)
+uint16_t CommandManager::determine_override_status()
 {
-  bool override_this_channel = false;
-  //Check if the override switch exists and is triggered, or if the sticks have deviated enough to trigger an override
-  if ((RF_.rc_.switch_mapped(RC::SWITCH_ATT_OVERRIDE) && RF_.rc_.switch_on(RC::SWITCH_ATT_OVERRIDE))
-      || stick_deviated(channel))
+  uint16_t rc_override{OVERRIDE_NO_OVERRIDE};
+  if(RF_.rc_.switch_mapped(RC::SWITCH_ATT_OVERRIDE) && RF_.rc_.switch_on(RC::SWITCH_ATT_OVERRIDE))
+    rc_override |= OVERRIDE_ATT_SWITCH;
+  if(RF_.rc_.switch_mapped(RC::SWITCH_THROTTLE_OVERRIDE) && RF_.rc_.switch_on(RC::SWITCH_THROTTLE_OVERRIDE))
+    rc_override |= OVERRIDE_THR_SWITCH;
+  for(uint8_t channel{0}; channel < MUX_F; channel++)
   {
-    override_this_channel = true;
+    if(stick_deviated(static_cast<MuxChannel>(channel)))
+      rc_override |= channel_override_[channel].stick_override_reason;
+    if(!(muxes[channel].onboard->active))
+      rc_override |= channel_override_[channel].offboard_inactive_override_reason;
   }
-  else // Otherwise only have RC override if the offboard channel is inactive
+  if(muxes[MUX_F].onboard->active) // The throttle has unique override behavior
   {
-    if (muxes[channel].onboard->active)
-    {
-      override_this_channel = false;
-    }
-    else
-    {
-      override_this_channel = true;
-    }
+    if(RF_.params_.get_param_int(PARAM_RC_OVERRIDE_TAKE_MIN_THROTTLE))
+      if(muxes[MUX_F].rc->value < muxes[MUX_F].onboard->value)
+        rc_override |= OVERRIDE_T;
   }
-  // set the combined channel output depending on whether RC is overriding for this channel or not
-  *muxes[channel].combined = override_this_channel ? *muxes[channel].rc : *muxes[channel].onboard;
-  return override_this_channel;
+  else
+    rc_override |= OVERRIDE_OFFBOARD_T_INACTIVE;
+  return rc_override;
 }
 
-bool CommandManager::do_throttle_muxing(void)
+void CommandManager::do_muxing(uint16_t rc_override)
 {
-  bool override_this_channel = false;
-  // Check if the override switch exists and is triggered
-  if (RF_.rc_.switch_mapped(RC::SWITCH_THROTTLE_OVERRIDE) && RF_.rc_.switch_on(RC::SWITCH_THROTTLE_OVERRIDE))
-  {
-    override_this_channel = true;
-  }
-  else // Otherwise check if the offboard throttle channel is active, if it isn't, have RC override
-  {
-    if (muxes[MUX_F].onboard->active)
-    {
-      // Check if the parameter flag is set to have us always take the smaller throttle
-      if (RF_.params_.get_param_int(PARAM_RC_OVERRIDE_TAKE_MIN_THROTTLE))
-      {
-        override_this_channel = (muxes[MUX_F].rc->value < muxes[MUX_F].onboard->value);
-      }
-      else
-      {
-        override_this_channel = false;
-      }
-    }
-    else
-    {
-      override_this_channel = true;
-    }
-  }
-
-  // Set the combined channel output depending on whether RC is overriding for this channel or not
-  *muxes[MUX_F].combined = override_this_channel ? *muxes[MUX_F].rc : *muxes[MUX_F].onboard;
-  return override_this_channel;
+  for(uint8_t channel{0}; channel <=MUX_F; channel++)
+    do_channel_muxing(static_cast<MuxChannel>(channel), rc_override);
+}
+void CommandManager::do_channel_muxing(MuxChannel channel, uint16_t rc_override)
+{
+  bool override_this_channel = (rc_override | channel_override_[channel].override_mask);
+  // set the combined channel output depending on whether RC is overriding for this channel or not
+  *muxes[channel].combined = override_this_channel ? *muxes[channel].rc : *muxes[channel].onboard;
 }
 
 bool CommandManager::rc_override_active()
@@ -291,10 +269,8 @@ bool CommandManager::run()
     }
 
     // Perform muxing
-    rc_override_  = do_roll_pitch_yaw_muxing(MUX_X);
-    rc_override_ |= do_roll_pitch_yaw_muxing(MUX_Y);
-    rc_override_ |= do_roll_pitch_yaw_muxing(MUX_Z);
-    rc_override_ |= do_throttle_muxing();
+    rc_override_ = determine_override_status();
+    do_muxing(rc_override_);
 
     // Light to indicate override
     if (rc_override_)

--- a/src/command_manager.cpp
+++ b/src/command_manager.cpp
@@ -205,12 +205,12 @@ void CommandManager::do_muxing(uint16_t rc_override)
 }
 void CommandManager::do_channel_muxing(MuxChannel channel, uint16_t rc_override)
 {
-  bool override_this_channel = (rc_override | channel_override_[channel].override_mask);
+  bool override_this_channel = (rc_override & channel_override_[channel].override_mask);
   // set the combined channel output depending on whether RC is overriding for this channel or not
   *muxes[channel].combined = override_this_channel ? *muxes[channel].rc : *muxes[channel].onboard;
 }
 
-bool CommandManager::rc_override_active()
+uint16_t CommandManager::get_rc_override()
 {
   return rc_override_;
 }

--- a/src/command_manager.cpp
+++ b/src/command_manager.cpp
@@ -243,7 +243,7 @@ void CommandManager::override_combined_command_with_rc()
 
 bool CommandManager::run()
 {
-  bool last_rc_override = rc_override_;
+  uint16_t last_rc_override = rc_override_;
 
   // Check for and apply failsafe command
   if (RF_.state_manager_.state().failsafe)

--- a/test/command_manager_test.cpp
+++ b/test/command_manager_test.cpp
@@ -335,6 +335,10 @@ TEST_F (CommandManagerTest, OffboardCommandMuxNoMinThrottle)
   stepFirmware(20000);
 
   control_t output = rf.command_manager_.combined_control();
+  uint16_t override = rf.command_manager_.get_rc_override();
+
+  EXPECT_EQ(override, 0x0);
+
   EXPECT_CLOSE(output.x.value, OFFBOARD_X);
   EXPECT_CLOSE(output.y.value, OFFBOARD_Y);
   EXPECT_CLOSE(output.z.value, OFFBOARD_Z);
@@ -352,6 +356,10 @@ TEST_F (CommandManagerTest, OffboardCommandMuxMinThrottle)
   stepFirmware(20000);
 
   control_t output = rf.command_manager_.combined_control();
+  uint16_t override = rf.command_manager_.get_rc_override();
+
+  EXPECT_EQ(override, 0x20);
+
   EXPECT_CLOSE(output.x.value, OFFBOARD_X);
   EXPECT_CLOSE(output.y.value, OFFBOARD_Y);
   EXPECT_CLOSE(output.z.value, OFFBOARD_Z);
@@ -368,6 +376,10 @@ TEST_F (CommandManagerTest, OffboardCommandMuxRollDeviation)
   stepFirmware(40000);
 
   control_t output = rf.command_manager_.combined_control();
+  uint16_t override = rf.command_manager_.get_rc_override();
+
+  EXPECT_EQ(override, 0x24);
+
   EXPECT_CLOSE(output.x.value, -0.5 * rf.params_.get_param_float(PARAM_RC_MAX_ROLL));
   EXPECT_CLOSE(output.y.value, OFFBOARD_Y);
   EXPECT_CLOSE(output.z.value, OFFBOARD_Z);
@@ -384,6 +396,10 @@ TEST_F (CommandManagerTest, OffboardCommandMuxPitchDeviation)
   stepFirmware(40000);
 
   control_t output = rf.command_manager_.combined_control();
+  uint16_t override = rf.command_manager_.get_rc_override();
+
+  EXPECT_EQ(override, 0x28);
+
   EXPECT_CLOSE(output.x.value, OFFBOARD_X);
   EXPECT_CLOSE(output.y.value, 0.5 * rf.params_.get_param_float(PARAM_RC_MAX_PITCH));
   EXPECT_CLOSE(output.z.value, OFFBOARD_Z);
@@ -400,6 +416,10 @@ TEST_F (CommandManagerTest, OffboardCommandMuxYawrateDeviation)
   stepFirmware(40000);
 
   control_t output = rf.command_manager_.combined_control();
+  uint16_t override = rf.command_manager_.get_rc_override();
+
+  EXPECT_EQ(override, 0x30);
+
   EXPECT_CLOSE(output.x.value, OFFBOARD_X);
   EXPECT_CLOSE(output.y.value, OFFBOARD_Y);
   EXPECT_CLOSE(output.z.value, -0.5 * rf.params_.get_param_float(PARAM_RC_MAX_YAWRATE));
@@ -417,6 +437,8 @@ TEST_F (CommandManagerTest, OffboardCommandMuxLag)
 
   control_t output = rf.command_manager_.combined_control();
   EXPECT_CLOSE(output.x.value, -0.5 * rf.params_.get_param_float(PARAM_RC_MAX_ROLL));
+  uint16_t override = rf.command_manager_.get_rc_override();
+  EXPECT_EQ(override, 0x20);
 
   rc_values[0] = 1500; // return stick to center
   board.set_rc(rc_values);
@@ -425,16 +447,22 @@ TEST_F (CommandManagerTest, OffboardCommandMuxLag)
   setOffboard(offboard_command);
   output=rf.command_manager_.combined_control();
   EXPECT_CLOSE(output.x.value, 0.0); // lag
+  override = rf.command_manager_.get_rc_override();
+  EXPECT_EQ(override, 0x24);
 
   stepFirmware(600000);
   setOffboard(offboard_command);
   output=rf.command_manager_.combined_control();
   EXPECT_CLOSE(output.x.value, 0.0); // lag
+  override = rf.command_manager_.get_rc_override();
+  EXPECT_EQ(override, 0x24);
 
   setOffboard(offboard_command);
   stepFirmware(20000);
   output=rf.command_manager_.combined_control();
   EXPECT_CLOSE(output.x.value, OFFBOARD_X);
+  override = rf.command_manager_.get_rc_override();
+  EXPECT_EQ(override, 0x20);
 }
 
 TEST_F (CommandManagerTest, StaleOffboardCommand)


### PR DESCRIPTION
This changes the RC Override variable in the status message from a boolean to a bitfield, that indicates specifically why RC is overriding offboard controls. This also allows you to tell which channels are overridden. There are corresponding changes to rosflight_io that show this in the status messages.