### PR TITLE
Auto release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,43 @@
+---
+name: "pre-release"
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  pre-release:
+    name: "Pre Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: clone
+      run: git submodule update --init --recursive
+    - name: install toolchain
+      run: curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2" | tar xfj -
+    - name: check toolchain
+      run: |
+        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
+        arm-none-eabi-gcc --version
+    - name: make_f4
+      run: |
+        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
+        make BOARD=REVO -j4 -l4
+    - name: make_f1
+      run: |
+        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
+        make BOARD=NAZE -j4 -l4
+
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "pre-release"
+        prerelease: true
+        title: "Development Build"
+        files: |
+          boards/airbourne/build/rosflight_REVO_Release.elf
+          boards/airbourne/build/rosflight_REVO_Release.bin
+          boards/breezy/build/rosflight_NAZE_Release.elf
+          boards/breezy/build/rosflight_NAZE_Release.hex

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,19 +16,15 @@ jobs:
     - name: clone
       run: git submodule update --init --recursive
     - name: install toolchain
-      run: curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2" | tar xfj -
+      run: |
+        sudo add-apt-repository -y -u ppa:team-gcc-arm-embedded/ppa
+        sudo apt -y install gcc-arm-embedded
     - name: check toolchain
-      run: |
-        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
-        arm-none-eabi-gcc --version
+      run: arm-none-eabi-gcc --version
     - name: make_f4
-      run: |
-        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
-        make BOARD=REVO -j4 -l4
+      run: make BOARD=REVO -j4 -l4
     - name: make_f1
-      run: |
-        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
-        make BOARD=NAZE -j4 -l4
+      run: make BOARD=NAZE -j4 -l4
 
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,15 @@ jobs:
     - name: clone
       run: git submodule update --init --recursive
     - name: install toolchain
-      run: curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2" | tar xfj -
+      run: |
+        sudo add-apt-repository -y -u ppa:team-gcc-arm-embedded/ppa
+        sudo apt -y install gcc-arm-embedded
     - name: check toolchain
-      run: |
-        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
-        arm-none-eabi-gcc --version
+      run: arm-none-eabi-gcc --version
     - name: make_f4
-      run: |
-        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
-        make BOARD=REVO -j4 -l4
+      run: make BOARD=REVO -j4 -l4
     - name: make_f1
-      run: |
-        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
-        make BOARD=NAZE -j4 -l4
+      run: make BOARD=NAZE -j4 -l4
 
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+---
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: clone
+      run: git submodule update --init --recursive
+    - name: install toolchain
+      run: curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2" | tar xfj -
+    - name: check toolchain
+      run: |
+        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
+        arm-none-eabi-gcc --version
+    - name: make_f4
+      run: |
+        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
+        make BOARD=REVO -j4 -l4
+    - name: make_f1
+      run: |
+        export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_3-2016q1/bin
+        make BOARD=NAZE -j4 -l4
+
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: false
+        files: |
+          boards/airbourne/build/rosflight_REVO_Release.elf
+          boards/airbourne/build/rosflight_REVO_Release.bin
+          boards/breezy/build/rosflight_NAZE_Release.elf
+          boards/breezy/build/rosflight_NAZE_Release.hex

--- a/comms/mavlink/mavlink.h
+++ b/comms/mavlink/mavlink.h
@@ -37,6 +37,8 @@
 #pragma GCC diagnostic ignored "-Wswitch-default"
 #pragma GCC diagnostic ignored "-Wcast-align"
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 #include "v1.0/rosflight/mavlink.h"
 # pragma GCC diagnostic pop
 


### PR DESCRIPTION
This PR adds two github actions.  
- The first releases the binaries (`.elf` and `.bin`) for both F1 and F4 targets for every push to `master`.  This is labeled as a `Pre-release` and named `Development Build`
 - The second automatically builds and releases binaries and source code for every git tag labeled according to `v1.3.0` or something like that.

After this PR is merged:
 - to update the current "pre-release" Development build, merge with `master`
 - to create a new release, `git tag` and `git push --tags origin`.

