### PR TITLE
Tweaks to automatic release/latest builds

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: clone
+    - name: checkout submodules
       run: git submodule update --init --recursive
     - name: install toolchain
       run: |
@@ -29,11 +29,9 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "pre-release"
+        automatic_release_tag: "latest"
         prerelease: true
         title: "Development Build"
         files: |
-          boards/airbourne/build/rosflight_REVO_Release.elf
           boards/airbourne/build/rosflight_REVO_Release.bin
-          boards/breezy/build/rosflight_NAZE_Release.elf
           boards/breezy/build/rosflight_NAZE_Release.hex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: clone
+    - name: checkout submodules
       run: git submodule update --init --recursive
     - name: install toolchain
       run: |
@@ -31,7 +31,5 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: false
         files: |
-          boards/airbourne/build/rosflight_REVO_Release.elf
           boards/airbourne/build/rosflight_REVO_Release.bin
-          boards/breezy/build/rosflight_NAZE_Release.elf
           boards/breezy/build/rosflight_NAZE_Release.hex


### PR DESCRIPTION
Changes:

## Change prerelease tag
Use "latest" instead of "pre-release"

Rationale: I think "pre-release" is misleading, since it has the implication that it's a release candidate build. I think latest conveys the meaning more clearly. And since it's also titled "Development build" and marked as a pre-release, I think it's pretty clear.

Also, this is the tag that will get used in the compiled-in version tag. I think that it makes more sense to get `latest-0-g1234abc` than `pre-release-0-g1234abc`.

## Don't attach .elf files

As far as I know we don't actually use these, right? So I think it avoids a point of confusion for people who are just trying to find the file they need to flash. They only have to choose Naze vs. Revo, not `.hex`/`.bin` vs. `.elf`