### PR TITLE
Fixed issues preventing linter checks with modern compilation packages

### DIFF
--- a/.github/workflows/f1_firmware.yml
+++ b/.github/workflows/f1_firmware.yml
@@ -12,9 +12,7 @@ jobs:
     - name: checkout submodules
       run: git submodule update --init --recursive
     - name: install toolchain
-      run: |
-        sudo add-apt-repository -y -u ppa:team-gcc-arm-embedded/ppa
-        sudo apt -y install gcc-arm-embedded
+      run: sudo apt -y install gcc-arm-none-eabi
     - name: check toolchain
       run: arm-none-eabi-gcc --version
     - name: make

--- a/.github/workflows/f4_firmware.yml
+++ b/.github/workflows/f4_firmware.yml
@@ -12,9 +12,7 @@ jobs:
     - name: checkout submodules
       run: git submodule update --init --recursive
     - name: install toolchain
-      run: |
-        sudo add-apt-repository -y -u ppa:team-gcc-arm-embedded/ppa
-        sudo apt -y install gcc-arm-embedded
+      run: sudo apt -y install gcc-arm-none-eabi
     - name: check toolchain
       run: arm-none-eabi-gcc --version
     - name: make

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,9 +16,7 @@ jobs:
     - name: checkout submodules
       run: git submodule update --init --recursive
     - name: install toolchain
-      run: |
-        sudo add-apt-repository -y -u ppa:team-gcc-arm-embedded/ppa
-        sudo apt -y install gcc-arm-embedded
+      run: sudo apt -y install gcc-arm-none-eabi
     - name: check toolchain
       run: arm-none-eabi-gcc --version
     - name: make_f4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ jobs:
     - name: checkout submodules
       run: git submodule update --init --recursive
     - name: install toolchain
-      run: |
-        sudo add-apt-repository -y -u ppa:team-gcc-arm-embedded/ppa
-        sudo apt -y install gcc-arm-embedded
+      run: sudo apt -y install gcc-arm-none-eabi
     - name: check toolchain
       run: arm-none-eabi-gcc --version
     - name: make_f4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
         cd /usr/src/gtest
         sudo cmake CMakeLists.txt 
         sudo make 
-        sudo cp *.a /usr/lib
+        sudo cp ./lib/libgtest*.a /usr/lib
     - name: cmake
       run: |
         cd test 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,10 +8,6 @@ repo_name: 'rosflight/firmware'
 repo_url: 'https://github.com/rosflight/firmware'
 edit_uri: 'blob/master/docs/'
 
-google_analytics:
-  - 'UA-96018590-2'
-  - 'auto'
-
 theme:
   name: 'material'
   language: 'en'
@@ -22,6 +18,8 @@ theme:
   logo: 'assets/logo.png'
   feature:
     tabs: true
+  analytics:
+    gtag: UA-96018590-2
 
 extra_javascript:
     - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML

--- a/src/nanoprintf.cpp
+++ b/src/nanoprintf.cpp
@@ -29,6 +29,8 @@
  * OF SUCH DAMAGE.
  */
 
+#pragma GCC diagnostic ignored "-Wstrict-overflow"
+
 #include "nanoprintf.h"
 
 namespace rosflight_firmware

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_definitions(-DGIT_VERSION_STRING=\"${GIT_VERSION_STRING}\")
 
 # Locate GTest
 find_package(GTest REQUIRED)
+find_package(Threads REQUIRED)  # Required for current gtest version, may be a bug with gtest?
 include_directories(${GTEST_INCLUDE_DIRS})
 
 include_directories(../include)


### PR DESCRIPTION
When attempting to compile the firmware and run all unit tests on a system using the updated compilation packages, a number of errors prevent the tests from passing. These include:

1. The apt repository that had previously been used to install the arm64 gcc compiler no longer has the required package. The github action files setting up the linter checks have been updated to pull from a valid apt repo.
2. gtest changed the install location of the files that needed to be installed for running the unit tests. The cp command installing these files has been updated.
3. nanoprintf.cpp was throwing strange strict-overflow errors. This could be due to a gcc bug. Since the file compiled fine previously, I disabled this warning for this file.
4. gtest requires the Threads::Threads library, but wasn't including it in the GTest package. I added a line in the unit test cmake file that finds the Threads package, solving the issue.
5. mkdocs has changed the syntax for google analytics. I updated the mkdocs.yml file to use the modern syntax.